### PR TITLE
Test methods they way the are used by the calling code

### DIFF
--- a/tests/unit/configuration/test_inheritance_break_validation.py
+++ b/tests/unit/configuration/test_inheritance_break_validation.py
@@ -20,8 +20,9 @@ class TestInheritanceBreakValidation:
                 value: bar
         """
 
+        configuration = Configuration(config_string=config_yaml)
         with pytest.raises(SystemExit) as exception:
-            Configuration(config_string=config_yaml).get_common_config()
+            configuration.get_common_config()
         assert exception.type == SystemExit
         assert exception.value.code == EXIT_INVALID_INPUT
 
@@ -37,12 +38,9 @@ class TestInheritanceBreakValidation:
                 value: bar
         """
 
-        group_name = "some_group"
-        configuration = Configuration(config_string=config_yaml).get_group_config(
-            group_name
-        )
+        configuration = Configuration(config_string=config_yaml)
         with pytest.raises(SystemExit) as exception:
-            Configuration.validate_break_inheritance_flag(configuration, group_name)
+            configuration.get_effective_config_for_group("some_group")
         assert exception.type == SystemExit
         assert exception.value.code == EXIT_INVALID_INPUT
 
@@ -58,14 +56,9 @@ class TestInheritanceBreakValidation:
                 value: bar
         """
 
-        group_and_project_name = "some_group/some_project"
-        configuration = Configuration(config_string=config_yaml).get_project_config(
-            group_and_project_name
-        )
+        configuration = Configuration(config_string=config_yaml)
         with pytest.raises(SystemExit) as exception:
-            Configuration.validate_break_inheritance_flag(
-                configuration, group_and_project_name
-            )
+            configuration.get_effective_config_for_project("some_group/some_project")
         assert exception.type == SystemExit
         assert exception.value.code == EXIT_INVALID_INPUT
 
@@ -80,11 +73,8 @@ class TestInheritanceBreakValidation:
                 access_level: 10
         """
 
-        subgroup_name = "some_group/subgroup"
-        configuration = Configuration(config_string=config_yaml).get_group_config(
-            subgroup_name
-        )
+        configuration = Configuration(config_string=config_yaml)
         with pytest.raises(SystemExit) as exception:
-            Configuration.validate_break_inheritance_flag(configuration, subgroup_name)
+            configuration.get_effective_config_for_group("some_group/subgroup")
         assert exception.type == SystemExit
         assert exception.value.code == EXIT_INVALID_INPUT


### PR DESCRIPTION
I thought that it would be better to have a test code more like the code that actually uses the methods that we test.

But after the change in this PR *some* tests don't pass:

```
/Users/gdubicki/git/gitlabform/venv/bin/python "/Users/gdubicki/Library/Application Support/JetBrains/IntelliJIdea2022.1/plugins/python/helpers/pycharm/_jb_pytest_runner.py" --path /Users/gdubicki/git/gitlabform/tests/unit/configuration
Testing started at 09:13 ...
Launching pytest with arguments /Users/gdubicki/git/gitlabform/tests/unit/configuration --no-header --no-summary -q in /Users/gdubicki/git/gitlabform/tests/unit/configuration

============================= test session starts ==============================
collecting ... collected 49 items

test_case_sensitivity.py::test__config_with_different_case_group 
test_case_sensitivity.py::test__config_with_different_case_project 
test_case_sensitivity.py::test__config_with_different_case_duplicate_groups 
test_case_sensitivity.py::test__config_with_different_case_duplicate_projects 
test_case_sensitivity.py::test__config_with_different_case_duplicate_skip_groups 
test_case_sensitivity.py::test__config_with_different_case_duplicate_skip_projects 
test_inheritance_break_projects_and_groups.py::TestInheritanceBreakProjectsAndGroups::test__inheritance_break__flag_set_at_project_level__project_inherits_nothing 
test_inheritance_break_subgroups.py::TestInheritanceBreakSubgroups::test__inheritance_break__flag_set_at_project_level__first_subgroup_project_inherits_nothing 
test_inheritance_break_subgroups.py::TestInheritanceBreakSubgroups::test__inheritance_break__flag_set_at_project_level__second_subgroup_project_inherits_nothing 
test_inheritance_break_subgroups.py::TestInheritanceBreakSubgroups::test__inheritance_break__flag_set_at_subgroup_level__second_subgroup_inherits_nothing 
test_inheritance_break_validation.py::TestInheritanceBreakValidation::test__validate_break_inheritance_flag__invalid_flag_set_at_common_level 
test_inheritance_break_validation.py::TestInheritanceBreakValidation::test__validate_break_inheritance_flag__invalid_flag_set_at_group_level PASSED  [  2%]PASSED [  4%]PASSED [  6%]Error: There are almost duplicates in the keys of projects_and_groups - they differ only in case.
They are: groupnamewithvaryingcase/*, GROUPnameWITHvaryingCASE/*
This is not allowed as we ignore the case for group and project names.
PASSED [  8%]Error: There are almost duplicates in the keys of projects_and_groups - they differ only in case.
They are: GroupNameWithVaryingCase/projectwithvaryingcase, GroupNameWithVaryingCase/ProjectWithVaryingCase
This is not allowed as we ignore the case for group and project names.
PASSED [ 10%]Error: There are almost duplicates in the keys of skip_groups - they differ only in case.
They are: groupnamewithvaryingcase, GROUPnameWITHvaryingCASE
This is not allowed as we ignore the case for group and project names.
PASSED [ 12%]Error: There are almost duplicates in the keys of skip_projects - they differ only in case.
They are: GroupNameWithVaryingCase/projectwithvaryingcase, GroupNameWithVaryingCase/ProjectWithVaryingCase
This is not allowed as we ignore the case for group and project names.

test_inheritance_break_projects_and_groups.py::TestInheritanceBreakProjectsAndGroups::test__inheritance_break__flag_set_at_project_level__project_inherits_group_and_not_common 
test_inheritance_break_projects_and_groups.py::TestInheritanceBreakProjectsAndGroups::test__inheritance_break__flag_set_at_group_level__group_inherits_nothing 
test_inheritance_break_projects_and_groups.py::TestInheritanceBreakProjectsAndGroups::test__inheritance_break__flag_set_at_group_level__group_is_highest_level_and_inherits_nothing 
test_inheritance_break_projects_and_groups.py::TestInheritanceBreakProjectsAndGroups::test__inheritance_break__flag_set_at_group_level__project_inherits_group_and_not_common 
test_inheritance_break_projects_and_groups.py::TestInheritanceBreakProjectsAndGroups::test__inheritance_break__flag_set_at_group_level_and_project_level__project_inherits_nothing 
test_inheritance_break_subgroups.py::TestInheritanceBreakSubgroups::test__inheritance_break__flag_set_at_subgroup_level__subgroup_inherits_nothing PASSED [ 14%]PASSED [ 16%]PASSED [ 18%]PASSED [ 20%]PASSED [ 22%]PASSED [ 24%]PASSED [ 26%]PASSED [ 28%]PASSED [ 30%]PASSED [ 32%]PASSED [ 34%]Error: The inheritance-break flag set in "*" is invalid
because it has no higher level setting to inherit from.

FAILED [ 36%]
tests/unit/configuration/test_inheritance_break_validation.py:28 (TestInheritanceBreakValidation.test__validate_break_inheritance_flag__invalid_flag_set_at_group_level)
self = <tests.unit.configuration.test_inheritance_break_validation.TestInheritanceBreakValidation object at 0x102709e40>

    def test__validate_break_inheritance_flag__invalid_flag_set_at_group_level(self):
        config_yaml = """
        ---
        projects_and_groups:
          some_group/*:
            secret_variables:
              inherit: false
              secret:
                key: foo
                value: bar
        """
    
        configuration = Configuration(config_string=config_yaml)
>       with pytest.raises(SystemExit) as exception:
E       Failed: DID NOT RAISE <class 'SystemExit'>

test_inheritance_break_validation.py:42: Failed
PASSED [ 38%]Error: The inheritance-break flag set in "some_group/some_project" under key "secret_variables" is invalid
because it has no higher level setting to inherit from.

FAILED [ 40%]
tests/unit/configuration/test_inheritance_break_validation.py:64 (TestInheritanceBreakValidation.test__validate_break_inheritance_flag__invalid_flag_set_at_subgroup_level)
self = <tests.unit.configuration.test_inheritance_break_validation.TestInheritanceBreakValidation object at 0x1027082b0>

    def test__validate_break_inheritance_flag__invalid_flag_set_at_subgroup_level(self):
        config_yaml = """
        ---
        projects_and_groups:
          some_group/subgroup/*:
            group_members:
              inherit: false
              my-user:
                access_level: 10
        """
    
        configuration = Configuration(config_string=config_yaml)
>       with pytest.raises(SystemExit) as exception:
E       Failed: DID NOT RAISE <class 'SystemExit'>

test_inheritance_break_validation.py:77: Failed






PASSED [ 42%]PASSED [ 44%]PASSED [ 46%]PASSED [ 48%]PASSED [ 51%]PASSED [ 53%]PASSED [ 55%]PASSED [ 57%]PASSED [ 59%]PASSED [ 61%]PASSED [ 63%]PASSED [ 65%]PASSED [ 67%]PASSED [ 69%]PASSED [ 71%]PASSED [ 73%]PASSED [ 75%]PASSED [ 77%]PASSED [ 79%]PASSED [ 81%]PASSED [ 83%]PASSED [ 85%]PASSED [ 87%]PASSED [ 89%]PASSED [ 91%]PASSED [ 93%]PASSED [ 95%]PASSED        [ 97%]PASSED                       [100%]






test_inheritance_break_validation.py::TestInheritanceBreakValidation::test__validate_break_inheritance_flag__invalid_flag_set_at_project_level 
test_inheritance_break_validation.py::TestInheritanceBreakValidation::test__validate_break_inheritance_flag__invalid_flag_set_at_subgroup_level 
test_projects_and_groups.py::test__get_effective_config_for_project__other_project 
test_projects_and_groups.py::test__get_effective_config_for_project__project_from_config__additive_project_settings 
test_projects_and_groups.py::test__get_effective_config_for_project__project_from_config__additive_hooks 
test_projects_and_groups.py::test__get_effective_config_for_project__with_multiple_levels 
test_projects_and_groups.py::test__get_effective_config_for_project__configuration_for_other_project 
test_skip_groups_skip_projects.py::test__config_skip_project[project-skip-True] 
test_skip_groups_skip_projects.py::test__config_skip_project[project-not-skip-False] 
test_skip_groups_skip_projects.py::test__config_skip_project[group-not-skip/project-not-skip-False] 
test_skip_groups_skip_projects.py::test__config_skip_project[group-skip/project-not-skip-False] 
test_skip_groups_skip_projects.py::test__config_skip_project[group-skip-wildcard/project-skip-True] 
test_skip_groups_skip_projects.py::test__config_skip_project[group-skip-wildcard/subgroup-a/project-skip-True] 
test_skip_groups_skip_projects.py::test__config_skip_project[group-skip-wildcard/subgroup-a/subgroup-b/project-skip-True] 
test_skip_groups_skip_projects.py::test__config_skip_project[group-not-skip/subgroup-not-skip/project-not-skip-False0] 
test_skip_groups_skip_projects.py::test__config_skip_project[group-not-skip/subgroup-skip-wildcard/project-skip-True] 
test_skip_groups_skip_projects.py::test__config_skip_project[group-not-skip/subgroup-not-skip/project-not-skip-False1] 
test_skip_groups_skip_projects.py::test__config_skip_project[group-not-skip/subgroup-skip/project-not-skip-False] 
test_skip_groups_skip_projects.py::test__config_skip_group[group-not-skip-False] 
test_skip_groups_skip_projects.py::test__config_skip_group[group-skip-True] 
test_skip_groups_skip_projects.py::test__config_skip_group[group-skip-wildcard-True] 
test_skip_groups_skip_projects.py::test__config_skip_group[group-skip-wildcard/subgroup-a-True] 
test_skip_groups_skip_projects.py::test__config_skip_group[group-skip-wildcard/subgroup-a/subgroup-b-True] 
test_skip_groups_skip_projects.py::test__config_skip_group[group-not-skip/subgroup-not-skip-False0] 
test_skip_groups_skip_projects.py::test__config_skip_group[group-not-skip/subgroup-skip-wildcard-True] 
test_skip_groups_skip_projects.py::test__config_skip_group[group-not-skip/subgroup-skip-wildcard/subgroup-skip-True] 
test_skip_groups_skip_projects.py::test__config_skip_group[group-not-skip/subgroup-not-skip-False1] 
test_subgroups.py::test__get_effective_config_for_project__project_from_config__level1 
test_subgroups.py::test__get_effective_config_for_project__project_from_config__level2 
test_subgroups.py::test__get_effective_config_for_subgroup 
test_yaml_version.py::test__default_yaml_11 

========================= 2 failed, 47 passed in 0.43s =========================

Process finished with exit code 1
```